### PR TITLE
Add number as note if it's typed in twice

### DIFF
--- a/Sudoku/Form1.cs
+++ b/Sudoku/Form1.cs
@@ -75,6 +75,7 @@ namespace Sudoku
         void cell_keyPressed(object sender, KeyPressEventArgs e)
         {
             var cell = (SudokuCell)sender;
+            bool useNote = false;
 
             if (cell.IsLocked)
                 return;
@@ -84,12 +85,14 @@ namespace Sudoku
             else if (e.KeyChar is >= '1' and <= '9')
             {
                 var number = int.Parse(e.KeyChar.ToString()).ToString();
-
-                if (!cell.Text.Contains(number))
-                    cell.Text += number;
+                useNote = cell.Text.Contains(number); // if cell already contains number, make it a note
+                if (!useNote)
+                {
+                  cell.Text += number;
+                }
             }
             
-            UpdateCellStyling(cell);
+            UpdateCellStyling(cell, useNote);
         }
 
         void cell_keyDowned(object sender, KeyEventArgs e)
@@ -105,14 +108,14 @@ namespace Sudoku
 	        UpdateCellStyling(cell);
         }
 
-        static void UpdateCellStyling(SudokuCell cell)
+        static void UpdateCellStyling(SudokuCell cell, bool useNote = false)
         {
-	        if (cell.Text.Length <= 1)
+	        if (cell.Text.Length <= 1 && !useNote)
 	        {
 		        cell.Font = new Font(SystemFonts.DefaultFont.FontFamily, 20);
 		        cell.ForeColor = SystemColors.ControlDarkDark;
 	        }
-	        else if (cell.Text.Length <= 6)
+	        else if (cell.Text.Length <= 6 || (cell.Text.Length <= 1 && useNote))
 	        {
 		        cell.Font = new Font(SystemFonts.DefaultFont.FontFamily, 14, FontStyle.Italic);
 		        cell.ForeColor = Color.DarkCyan;

--- a/Sudoku/Form1.cs
+++ b/Sudoku/Form1.cs
@@ -81,7 +81,12 @@ namespace Sudoku
                 return;
 
             if (e.KeyChar == '\b' && cell.Text.Length >= 1)
+            {
                 cell.Text = cell.Text.Remove(cell.Text.Length - 1);
+                if (cell.Text.Length == 1){
+                  useNote = true;
+                }
+            }
             else if (e.KeyChar is >= '1' and <= '9')
             {
                 var number = int.Parse(e.KeyChar.ToString()).ToString();


### PR DESCRIPTION
### **Problem**
There is limited support for notes within cells. While we can type in multiple numbers to a cell and have them appear green and italicized, there isn't a way to add in a single number as a note.

![Not able to add](https://github.com/Jarno458/Sudoku-for-Archipelago/assets/10749853/219ae28d-0ec6-4c09-b9a0-48554c89ea60)

_[Gif description: Sudoku board with the user failing to add in a note for a single number]_

### **Solution**
![Able to add note](https://github.com/Jarno458/Sudoku-for-Archipelago/assets/10749853/5b87c402-c034-4dc9-9717-8437b52c716b)
_[Gif description: Sudoku board with the user able to add in a note for a single number]_

If the number has already been typed within a cell, when the user types in that number again, style it as a note.

### **Future work**
I'd like to add even more note support in the future, or at least make it clearer that typing multiple numbers makes a note.

### **How to test**

- [ ] Clone this branch
- [ ] Build the project
- [ ] Once the program is open, hover over a cell. 
- [ ] Type "1" once to add an input
- [ ] Type "1" again. The 1 in the cell should now be italicized and green.