### PR TITLE
Improve key controls, add better marking support

### DIFF
--- a/Sudoku/Form1.Designer.cs
+++ b/Sudoku/Form1.Designer.cs
@@ -45,6 +45,11 @@
             this.DeathLinkCheckBox = new System.Windows.Forms.CheckBox();
             this.lblPassword = new System.Windows.Forms.Label();
             this.PasswordText = new System.Windows.Forms.TextBox();
+            this.label4 = new System.Windows.Forms.Label();
+            this.label5 = new System.Windows.Forms.Label();
+            this.entryNormal = new System.Windows.Forms.RadioButton();
+            this.entryCenter = new System.Windows.Forms.RadioButton();
+            this.panelEntryMode = new System.Windows.Forms.Panel();
             this.SuspendLayout();
             // 
             // panel1
@@ -224,11 +229,68 @@
             this.PasswordText.Size = new System.Drawing.Size(521, 31);
             this.PasswordText.TabIndex = 102;
             // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Font = new System.Drawing.Font("Segoe UI", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.label4.Location = new System.Drawing.Point(693, 247);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(57, 30);
+            this.label4.TabIndex = 103;
+            this.label4.Text = "Entry Mode";
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Font = new System.Drawing.Font("Segoe UI", 7F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.label5.Location = new System.Drawing.Point(775, 252);
+            this.label5.Name = "label3";
+            this.label5.Size = new System.Drawing.Size(57, 30);
+            this.label5.TabIndex = 104;
+            this.label5.Text = "(Press Tab or Hold Shift to toggle)";
+            //
+            // panelEntryMode
+            //
+            this.panelEntryMode.Controls.Add(entryNormal);
+            this.panelEntryMode.Controls.Add(entryCenter);
+            this.panelEntryMode.Location = new System.Drawing.Point(709, 270);
+            this.panelEntryMode.Size = new System.Drawing.Size(106, 78);
+            // 
+            // entryNormal
+            // 
+            this.entryNormal.AutoSize = true;
+            this.entryNormal.Checked = true;
+            this.entryNormal.Location = new System.Drawing.Point(0, 0);
+            this.entryNormal.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.entryNormal.Name = "entryNormal";
+            this.entryNormal.Size = new System.Drawing.Size(106, 29);
+            this.entryNormal.TabIndex = 105;
+            this.entryNormal.TabStop = true;
+            this.entryNormal.Text = "Normal";
+            this.entryNormal.UseVisualStyleBackColor = true;
+            this.entryNormal.CheckedChanged += SetEntryNormal;
+            // 
+            // entryCenter
+            // 
+            this.entryCenter.AutoSize = true;
+            this.entryCenter.Location = new System.Drawing.Point(0, 20);
+            this.entryCenter.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.entryCenter.Name = "entryCenter";
+            this.entryCenter.Size = new System.Drawing.Size(106, 29);
+            this.entryCenter.TabIndex = 106;
+            this.entryCenter.TabStop = true;
+            this.entryCenter.Text = "Center";
+            this.entryCenter.UseVisualStyleBackColor = true;
+            this.entryCenter.CheckedChanged += SetEntryCenter;
+            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1226, 957);
+            this.Controls.Add(this.label4);
+            this.Controls.Add(this.label5);
+            this.Controls.Add(this.panelEntryMode);
             this.Controls.Add(this.PasswordText);
             this.Controls.Add(this.lblPassword);
             this.Controls.Add(this.DeathLinkCheckBox);
@@ -273,6 +335,11 @@
         private System.Windows.Forms.CheckBox DeathLinkCheckBox;
         private System.Windows.Forms.Label lblPassword;
         private System.Windows.Forms.TextBox PasswordText;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.RadioButton entryNormal;
+        private System.Windows.Forms.RadioButton entryCenter;
+        private System.Windows.Forms.Panel panelEntryMode;
     }
 }
 

--- a/Sudoku/Form1.cs
+++ b/Sudoku/Form1.cs
@@ -213,6 +213,7 @@ namespace Sudoku
                 {
                     var cell = cells[x, y];
 
+                    cell.Clear();
                     cell.Value = solved[x, y].Value;
                     cell.Font = new Font(SystemFonts.DefaultFont.FontFamily, 20);
 

--- a/Sudoku/SudokuCell.cs
+++ b/Sudoku/SudokuCell.cs
@@ -25,7 +25,8 @@ namespace Sudoku
             this.IsLocked = false;
             this.Text = string.Empty;
             this.FilledVal = 0;
-            this.MarkedVals.Initialize();
+            for (var q = 0; q < 9; ++q)
+                this.MarkedVals[q] = false;
         }
 
         // Clears the marks in a cell.
@@ -36,7 +37,8 @@ namespace Sudoku
                 return;
             if(this.FilledVal > 0)
                 this.FilledVal = 0;
-            else this.MarkedVals.Initialize();
+            else for (var q = 0; q < 9; ++q)
+                this.MarkedVals[q] = false;
             UpdateCell();
         }
 

--- a/Sudoku/SudokuCell.cs
+++ b/Sudoku/SudokuCell.cs
@@ -1,18 +1,102 @@
-﻿using System.Windows.Forms;
+﻿using System.Drawing;
+using System.Windows.Forms;
 
 namespace Sudoku
 {
+    enum EntryMode
+    {
+        Normal, //Enter the 'answer' for a cell
+        Center, //Enter a 'center mark' in the cell
+    }
     class SudokuCell : Button
     {
-        public int Value { get; set; }
-        public bool IsLocked { get; set; }
+        public int Value { get; set; } //The 'correct' value for the cell
+        public bool IsLocked { get; set; } //If the cell was one of the 'given digits', and is uneditable
         public int X { get; set; }
         public int Y { get; set; }
+        public int FilledVal { get; set; } //The user's 'answer' for the cell
+        public bool[] MarkedVals = new bool[9]; //The user's pencilmarks for the cell (indx 0-8 = 1-9)
 
-        public void Clear()
+        static Color UserColor = Color.FromArgb(30, 107, 229); //The color of user-entered numbers
+        static Color LockedColor = Color.Black; //The color of 'given digits'
+
+        public void Clear() //Clear the cell entirely
         {
-            this.Text = string.Empty;
             this.IsLocked = false;
+            this.Text = string.Empty;
+            this.FilledVal = 0;
+            this.MarkedVals.Initialize();
+        }
+
+        // Clears the marks in a cell.
+        // If there is a 'FilledVal', only that is cleared.
+        public void ClearMarks()
+        {
+            if (this.IsLocked)
+                return;
+            if(this.FilledVal > 0)
+                this.FilledVal = 0;
+            else this.MarkedVals.Initialize();
+            UpdateCell();
+        }
+
+        //Enter a number into a cell, either as an answer or centermark
+        public void Mark(int num, EntryMode mode)
+        {
+            if (this.IsLocked)
+                return;
+            if (num < 1 || num > 9)
+                return;
+            bool shift = (Control.ModifierKeys & Keys.Shift) == Keys.Shift;
+            if (shift) //Toggle EntryMode.Center if shift is down
+            {
+                if (mode == EntryMode.Center)
+                    mode = EntryMode.Normal;
+                else mode = EntryMode.Center;
+            }
+            switch (mode)
+            {
+                case EntryMode.Normal:
+                    if (this.FilledVal == num)
+                        this.FilledVal = 0;
+                    else this.FilledVal = num;
+                    break;
+                case EntryMode.Center:
+                    if (this.FilledVal > 0)
+                        break;
+                    this.MarkedVals[num-1] = !this.MarkedVals[num-1];
+                    break;
+            }
+        }
+
+        //Update the visual of the cell to match it's current contents
+        public void UpdateCell()
+        {
+            if (this.FilledVal > 0)
+            {
+                this.Text = this.FilledVal.ToString();
+                this.Font = new Font(SystemFonts.DefaultFont.FontFamily, 20);
+            }
+            else
+            {
+                this.Text = string.Empty;
+                for(int q = 1; q <= 9; ++q)
+                {
+                    if (this.MarkedVals[q-1])
+                        this.Text += q.ToString();
+                }
+                this.Font = new Font(SystemFonts.DefaultFont.FontFamily, this.Text.Length < 6 ? 14 : 8, FontStyle.Italic);
+            }
+            this.ForeColor = this.IsLocked ? LockedColor : UserColor;
+        }
+
+        //Prevents an ugly border from appearing after pressing 'Tab'
+        protected override bool ShowFocusCues
+        {
+            get
+            {
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
- "Answer" numbers and "marking" numbers are now handled separately, allowing you to enter markings and then type an answer OVER them.
  - The markings will now always appear in numerical order 
  - As such, markings now require a separate entry mode- selected via radiobutton, toggled via tab, or temporarily toggled while holding Shift.
  - This DOES override Tab's normal feature of cycling through selected objects... if that's an issue, the tab toggle can be changed to some other key.
- Arrow keys now navigate the grid properly
- Backspace/Delete now will delete all markings instead of the rightmost marking; or, if an answer is placed in a cell, it will delete the answer (without deleting markings that were hiding underneath the answer).
- Changed the text color of user-entered numbers (Both markings AND answers) to better differentiate user-entered numbers from given digits. These colors are now static near the top of `SudokuCell.cs` for ease-of-changing.

Overall, these changes attempt to bring this more in line with [SudokuPad](https://store.steampowered.com/app/1706870/Svens_SudokuPad/) used by Cracking the Cryptic.
(More ideas from this that would be useful would include multi-highlighting to enter into multiple cells at once, and a third entry mode for corner-marking, though the former is a bit beyond me, and the latter I'm not sure how to go about displaying the numbers properly - would probably require a fair bit of work, and new UI elements on each cell...)

This fixes #3, and makes #5 and #8 redundant.