### PR TITLE
Change Hints from in your world to things for your world.

### DIFF
--- a/Sudoku/Form1.cs
+++ b/Sudoku/Form1.cs
@@ -220,7 +220,7 @@ namespace Sudoku
 
                     var missing = session.Locations.AllMissingLocations;
                     var alreadyHinted = session.DataStorage.GetHints()
-                        .Where(h => h.FindingPlayer == session.ConnectionInfo.Slot)
+                        .Where(h => h.ReceivingPlayer == session.ConnectionInfo.Slot)
                         .Select(h => h.LocationId);
 
                     var availableForHinting = missing.Except(alreadyHinted).ToArray();


### PR DESCRIPTION
Sudoku is typically played by those stuck in BK mode, as even stated by the name in archipelago: https://archipelago.gg/games/Sudoku/info/en

As such, I would consider it to make more sense for solving a puzzle to reward a hint that says where something you may need is, rather than an item you could find, if you weren't stuck in BK mode. 
This also opens the door to adding additional filters such as "Please find progression items"

I would be happy to modify this to make it a toggleable option. 